### PR TITLE
feat: improve mobile ui and styling

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,8 @@
 // SillyTavern-state 扩展脚本
 (function() {
-    const context = SillyTavern.getContext();
-    const { eventSource, event_types, chatMetadata, saveMetadata } = context;
+    function init() {
+        const context = SillyTavern.getContext();
+        const { eventSource, event_types, chatMetadata, saveMetadata } = context;
 
     // 扩展在 chatMetadata 中使用的键名:contentReference[oaicite:0]{index=0}
     const META_KEY = 'sillyTavernState';
@@ -266,6 +267,13 @@
         }
     };
     eventSource.on(event_types.MESSAGE_RECEIVED, globalThis.stateExt.msgHandler);
+    }
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', init);
+    } else {
+        init();
+    }
 })();
 
 // 提示拦截器：在生成请求前插入当前状态（系统提示）

--- a/manifest.json
+++ b/manifest.json
@@ -4,7 +4,7 @@
   "js": "index.js",
   "css": "style.css",
   "author": "ExampleAuthor",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "homePage": "https://github.com/yourname/SillyTavern-state",
   "auto_update": true,
   "minimum_client_version": "1.13.2",

--- a/style.css
+++ b/style.css
@@ -4,7 +4,16 @@
     bottom: 10px;
     right: 10px;
     z-index: 9999;
-    padding: 5px 10px;
+    padding: 6px 12px;
+    font-size: 14px;
+    background: #444;
+    color: #fff;
+    border: none;
+    border-radius: 4px;
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.3);
+    display: flex;
+    align-items: center;
+    justify-content: center;
 }
 
 /* 悬浮状态栏面板样式 */
@@ -14,13 +23,16 @@
     right: 10px;
     z-index: 9999;
     display: none;
-    background: rgba(0, 0, 0, 0.8);
+    background: #202020;
     color: #fff;
     padding: 10px;
-    border-radius: 5px;
+    border: 1px solid #555;
+    border-radius: 6px;
     max-width: 300px;
     max-height: 400px;
     overflow-y: auto;
+    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.5);
+    font-size: 14px;
 }
 
 /* 面板标题栏 */
@@ -53,14 +65,44 @@
     width: 40%;
     margin-right: 4px;
     box-sizing: border-box;
+    font-size: 14px;
 }
 #stateExtPanel button {
     margin: 2px 4px 2px 0;
-    padding: 2px 6px;
+    padding: 4px 8px;
     cursor: pointer;
+    font-size: 14px;
 }
 #stateExtPanel textarea {
     width: 100%;
     box-sizing: border-box;
     margin-bottom: 4px;
+    font-size: 14px;
+}
+
+@media (max-width: 600px) {
+    #stateExtToggleBtn {
+        bottom: 60px;
+        right: 10px;
+        padding: 4px 8px;
+        font-size: 12px;
+    }
+
+    #stateExtPanel {
+        bottom: 0;
+        right: 0;
+        left: 0;
+        width: 100%;
+        max-width: none;
+        height: 50%;
+        max-height: none;
+        border-radius: 10px 10px 0 0;
+        font-size: 12px;
+    }
+
+    #stateExtPanel input[type="text"],
+    #stateExtPanel button,
+    #stateExtPanel textarea {
+        font-size: 12px;
+    }
 }


### PR DESCRIPTION
## Summary
- initialize extension UI after DOM is ready to improve mobile compatibility
- refine status button and panel styling with smaller fonts
- add responsive rules for better mobile layout

## Testing
- `node --check index.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c80edd2460832b9a5cef3caacc6d94