### PR TITLE
Enhance state panel mobile UI

### DIFF
--- a/index.js
+++ b/index.js
@@ -58,7 +58,7 @@
         stateList.forEach((item, idx) => {
             const li = document.createElement('li');
             li.innerHTML = `
-                <span class="state-name">${item.name}</span:
+                <span class="state-name">${item.name}</span>
                 <span class="state-value">${item.value}</span>
                 <input class="edit-name" type="text" style="display:none;" />
                 <input class="edit-value" type="text" style="display:none;" />

--- a/style.css
+++ b/style.css
@@ -3,14 +3,18 @@
     position: fixed;
     bottom: 10px;
     right: 10px;
-    z-index: 9999;
+    /* 确保按钮始终位于面板之上 */
+    z-index: 10000;
     padding: 6px 12px;
-    font-size: 14px;
-    background: #444;
+    font-size: 12px;
+    font-family: 'Orbitron', 'Courier New', monospace;
+    /* 赛博朋克霓虹渐变 */
+    background: linear-gradient(90deg, #ff0080, #00f0ff);
     color: #fff;
     border: none;
     border-radius: 4px;
-    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.3);
+    box-shadow: 0 0 8px #ff0080, 0 0 12px #00f0ff;
+    text-shadow: 0 0 4px #fff;
     display: flex;
     align-items: center;
     justify-content: center;
@@ -23,16 +27,17 @@
     right: 10px;
     z-index: 9999;
     display: none;
-    background: #202020;
+    background: rgba(20, 20, 40, 0.95);
     color: #fff;
     padding: 10px;
-    border: 1px solid #555;
+    border: 1px solid #00f0ff;
     border-radius: 6px;
     max-width: 300px;
     max-height: 400px;
     overflow-y: auto;
-    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.5);
-    font-size: 14px;
+    box-shadow: 0 0 12px #00f0ff;
+    font-size: 12px;
+    font-family: 'Orbitron', 'Courier New', monospace;
 }
 
 /* 面板标题栏 */
@@ -40,8 +45,7 @@
     font-weight: bold;
     cursor: move;
     margin-bottom: 8px;
-    /* 可选：加入背景或边框使其更突出 */
-    /* background: #444; padding: 5px; border-bottom: 1px solid #666; */
+    color: #ff0080;
 }
 
 /* 状态列表样式 */
@@ -51,13 +55,19 @@
     padding: 0;
 }
 #stateExtPanel li {
-    margin-bottom: 5px;
+    margin-bottom: 6px;
+    border-bottom: 1px solid #333;
+    padding-bottom: 3px;
 }
 #stateExtPanel .state-name {
     font-weight: bold;
+    color: #00f0ff;
+    display: block;
 }
 #stateExtPanel .state-value {
-    margin-left: 4px;
+    margin-left: 0;
+    color: #fffb00;
+    display: block;
 }
 
 /* 编辑输入框和按钮 */
@@ -65,27 +75,38 @@
     width: 40%;
     margin-right: 4px;
     box-sizing: border-box;
-    font-size: 14px;
+    font-size: 12px;
+    background: #111;
+    color: #00f0ff;
+    border: 1px solid #00f0ff;
 }
 #stateExtPanel button {
     margin: 2px 4px 2px 0;
     padding: 4px 8px;
     cursor: pointer;
-    font-size: 14px;
+    font-size: 12px;
+    background: linear-gradient(90deg, #ff0080, #00f0ff);
+    color: #fff;
+    border: none;
+    box-shadow: 0 0 6px #ff0080;
 }
 #stateExtPanel textarea {
     width: 100%;
     box-sizing: border-box;
     margin-bottom: 4px;
-    font-size: 14px;
+    font-size: 12px;
+    background: #111;
+    color: #00f0ff;
+    border: 1px solid #00f0ff;
 }
 
 @media (max-width: 600px) {
     #stateExtToggleBtn {
-        bottom: 60px;
+        top: 10px;
+        bottom: auto;
         right: 10px;
         padding: 4px 8px;
-        font-size: 12px;
+        font-size: 10px;
     }
 
     #stateExtPanel {
@@ -97,12 +118,12 @@
         height: 50%;
         max-height: none;
         border-radius: 10px 10px 0 0;
-        font-size: 12px;
+        font-size: 10px;
     }
 
     #stateExtPanel input[type="text"],
     #stateExtPanel button,
     #stateExtPanel textarea {
-        font-size: 12px;
+        font-size: 10px;
     }
 }


### PR DESCRIPTION
## Summary
- Add neon cyberpunk styling to state panel and controls
- Show toggle button on mobile with higher z-index and top-right placement
- Reduce status text sizing and show each state entry on its own line

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c817597c34832b823b1f7c687f6035